### PR TITLE
Add fix to fix accuracy of timeseries data

### DIFF
--- a/src/pages/api/models/populate.ts
+++ b/src/pages/api/models/populate.ts
@@ -26,10 +26,10 @@ handler.post(
       return res.status(401).json({ message: "Forbidden" })
     }
 
+    res.status(200).json({ message: "ok" });
     //Is admin, proceed to populate/refresh database
     await dailyJob();
 
-    return res.status(200).json({ message: "ok" });
   }
 )
 


### PR DESCRIPTION
- Previous data may have inaccuracies, repopulated

Previously:
- Mapped pricepoints to sales, token movement, owner count by index
- May have been inaccurate especially for missing points
- Points queried at 00:00 UTC timestamp daily have high chance of being 0 due to insufficient data

Fix:
- Individual metrics query and upsert their own timepoints based off timestamp
- Points are guaranteed to be accurate
- Points for past 7 days are queried daily to ensure recency